### PR TITLE
Fix numpy deprecations

### DIFF
--- a/src/MEArec/cli.py
+++ b/src/MEArec/cli.py
@@ -405,6 +405,9 @@ def gen_recordings(params, **kwargs):
     if kwargs["filt_cutoff"] is not None:
         if isinstance(kwargs["filt_cutoff"], tuple):
             kwargs["filt_cutoff"] = list(kwargs["filt_cutoff"])
+        # for high-pass filter, make a scalar
+        if len(kwargs["filt_cutoff"]) == 1:
+            kwargs["filt_cutoff"] = kwargs["filt_cutoff"][0]
         params_dict["recordings"]["filter_cutoff"] = kwargs["filt_cutoff"]
     if kwargs["filt_order"] is not None:
         params_dict["recordings"]["filt_order"] = kwargs["filt_order"]

--- a/src/MEArec/generators/recordinggenerator.py
+++ b/src/MEArec/generators/recordinggenerator.py
@@ -1412,7 +1412,7 @@ class RecordingGenerator:
             if cutoff.size == 1:
                 pad_samples_filt = 3 * int((1.0 / cutoff * fs).magnitude[0])
             elif cutoff.size == 2:
-                pad_samples_filt = 3 * int((1.0 / cutoff[0] * fs).magnitude[0])
+                pad_samples_filt = 3 * int((1.0 / cutoff[0] * fs).magnitude)
 
             # call the loop on chunks
             args = (

--- a/src/MEArec/generators/recordinggenerator.py
+++ b/src/MEArec/generators/recordinggenerator.py
@@ -1410,7 +1410,7 @@ class RecordingGenerator:
 
             # compute pad samples as 3 times the low-cutoff period
             if cutoff.size == 1:
-                pad_samples_filt = 3 * int((1.0 / cutoff * fs).magnitude[0])
+                pad_samples_filt = 3 * int((1.0 / cutoff * fs).magnitude)
             elif cutoff.size == 2:
                 pad_samples_filt = 3 * int((1.0 / cutoff[0] * fs).magnitude)
 

--- a/src/MEArec/generators/recordinggenerator.py
+++ b/src/MEArec/generators/recordinggenerator.py
@@ -1410,9 +1410,9 @@ class RecordingGenerator:
 
             # compute pad samples as 3 times the low-cutoff period
             if cutoff.size == 1:
-                pad_samples_filt = 3 * int((1.0 / cutoff * fs).magnitude)
+                pad_samples_filt = 3 * int((1.0 / cutoff * fs).magnitude[0])
             elif cutoff.size == 2:
-                pad_samples_filt = 3 * int((1.0 / cutoff[0] * fs).magnitude)
+                pad_samples_filt = 3 * int((1.0 / cutoff[0] * fs).magnitude[0])
 
             # call the loop on chunks
             args = (

--- a/src/MEArec/simulate_cells.py
+++ b/src/MEArec/simulate_cells.py
@@ -1107,7 +1107,7 @@ def return_extracellular_spike(
             random rotation matrix
         """
         gamma = np.random.uniform(0, 2.0 * np.pi)
-        rotation_z = np.matrix([[np.cos(gamma), -np.sin(gamma), 0], [np.sin(gamma), np.cos(gamma), 0], [0, 0, 1]])
+        rotation_z = np.array([[np.cos(gamma), -np.sin(gamma), 0], [np.sin(gamma), np.cos(gamma), 0], [0, 0, 1]])
         x = np.random.uniform(size=2)
         v = np.array(
             [np.cos(2.0 * np.pi * x[0]) * np.sqrt(x[1]), np.sin(2.0 * np.pi * x[0]) * np.sqrt(x[1]), np.sqrt(1 - x[1])]


### PR DESCRIPTION
I noticed when I was looking at my other PR that in the testing,`MEArec` has a couple deprecations that will eventually become hard errors related to NumPy. 

There were also elephant deprecations, but since I don't know the package as well I didn't try to fix those.