### PR TITLE
Correct gain in output with float recording

### DIFF
--- a/src/MEArec/generators/recordinggenerator.py
+++ b/src/MEArec/generators/recordinggenerator.py
@@ -729,6 +729,8 @@ class RecordingGenerator:
                         gain = 1.0 / gain_to_int
                 else:
                     gain_to_int = 1.0 / gain
+            else:
+                gain = 1.0  # Necessary to output the correct gain used
         else:
             if tempgen is not None:
                 if celltype_params is not None:
@@ -867,6 +869,8 @@ class RecordingGenerator:
                             gain = 1.0 / gain_to_int
                     else:
                         gain_to_int = 1.0 / gain
+                else:
+                    gain = 1.0  # Necessary to output the correct gain used
 
                 if gain_to_int is not None:
                     if verbose_1:


### PR DESCRIPTION
Right now there is a problem, where a non-one gain with a flaot recording will output a different gain than the one used,

So when loading with SpikeInterface, the traces are wrongly scaled.