### PR TITLE
Fix grid plots on newer matplotlib versions

### DIFF
--- a/src/MEArec/tools.py
+++ b/src/MEArec/tools.py
@@ -3098,7 +3098,7 @@ def plot_templates(
         else:
             colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 
-        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax)
+        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax.get_subplotspec())
 
         for i_n, n in enumerate(template_ids):
             r = i_n // ncols
@@ -3318,7 +3318,7 @@ def plot_waveforms(
             nrows = 1
             ncols = n_units
 
-        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax)
+        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax.get_subplotspec())
 
         for i, wf in enumerate(waveforms):
             r = i // ncols
@@ -3336,7 +3336,7 @@ def plot_waveforms(
             nrows = 1
             ncols = len(spiketrain_id)
 
-        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax)
+        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax.get_subplotspec())
 
         # find ylim
         min_wf = 0
@@ -3488,7 +3488,7 @@ def plot_amplitudes(
             nrows = 1
             ncols = n_units
 
-        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax)
+        gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax.get_subplotspec())
 
         for i_n, n in enumerate(spiketrain_id):
             r = i_n // ncols
@@ -3626,7 +3626,7 @@ def plot_pca_map(
 
     nrows = len(pc_dims) * len(elec_dims)
     ncols = nrows
-    gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax)
+    gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax.get_subplotspec())
 
     for p1 in pc_dims:
         for i1, ch1 in enumerate(elec_dims):


### PR DESCRIPTION
Grid plots fail on `matplotlib` 3.9.2 with the following trace : 

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[17], line 1
----> 1 mr.plot_waveforms(recgen, electrode='max', cmap='rainbow')

File ~/Documents/GitHub/MEArec/src/MEArec/tools.py:3339, in plot_waveforms(recgen, spiketrain_id, ax, color, cmap, electrode, max_waveforms, ncols, cut_out)
   3336     nrows = 1
   3337     ncols = len(spiketrain_id)
-> 3339 gs = gridspec.GridSpecFromSubplotSpec(nrows, ncols, subplot_spec=ax)
   3341 # find ylim
   3342 min_wf = 0

File ~/.conda/envs/simul/lib/python3.10/site-packages/matplotlib/gridspec.py:490, in GridSpecFromSubplotSpec.__init__(self, nrows, ncols, subplot_spec, wspace, hspace, height_ratios, width_ratios)
    488     self._subplot_spec = subplot_spec
    489 else:
--> 490     raise TypeError(
    491                     "subplot_spec must be type SubplotSpec, "
    492                     "usually from GridSpec, or axes.get_subplotspec.")
    493 self.figure = self._subplot_spec.get_gridspec().figure
    494 super().__init__(nrows, ncols,
    495                  width_ratios=width_ratios,
    496                  height_ratios=height_ratios)

TypeError: subplot_spec must be type SubplotSpec, usually from GridSpec, or axes.get_subplotspec.
```

The `matplotlib` blame traces back to [this commit](https://github.com/matplotlib/matplotlib/commit/77c632527ef2ce3328f23453042521c7099b0ee0) which seems to have shipped with the latest version.

The fix involves explicitely calling `ax.get_subplotspec()` instead of just passing `ax`.
It doesn't seem to be a breaking change, and I've successfully tested it with `matplotlib` 3.8.0